### PR TITLE
Fix crash with the user agent parser when user_agent is None

### DIFF
--- a/pyramid_useragent/__init__.py
+++ b/pyramid_useragent/__init__.py
@@ -27,7 +27,7 @@ def get_user_agent_parsed(request):
     return UserAgent(request.user_agent)
 
 def get_user_agent_classified(request):
-    return UserAgentClassifier(request.user_agent)
+    return UserAgentClassifier(request.user_agent or '')
 
 
 class UserAgentComponent(object):

--- a/pyramid_useragent/tests.py
+++ b/pyramid_useragent/tests.py
@@ -28,6 +28,15 @@ class TestPyramidUserAgent(unittest.TestCase):
         self.assertIsInstance(resp, UserAgentClassifier)
         self.assertTrue(resp.is_mobile)
 
+    def test_no_user_agent(self):
+        from pyramid_useragent import (get_user_agent_classified, UserAgentClassifier)
+
+        request = mock.Mock()
+        request.user_agent = None
+
+        resp = get_user_agent_classified(request)
+        self.assertIsInstance(resp, UserAgentClassifier)
+
     def test_safety(self):
         from pyramid_useragent import UserAgent
 


### PR DESCRIPTION
The project has been moved over to Github. This [issue](https://bitbucket.org/pior/pyramid_useragent/issues/3/fails-if-requestuser_agent-is-none) was reported on Bitbucket

Closes #2 

Ping @goodspark 