### PR TITLE
Use PyReleaser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,10 +74,19 @@ Usage
 Tests
 -----
 
+For development, this project uses a tool called `DevBuddy <https://github.com/devbuddy/devbuddy>`_.
+
+To install DevBuddy, go to the `install page on Github <https://github.com/devbuddy/devbuddy#install>`_
+Once installed, you should be able to run ``bud up`` to setup your development
+environment.
+
+If you don't want to use DevBuddy, take a look at the file `dev.yml` to know
+how the project is setup, linted, tested, released.
+
+
 .. code-block:: python
 
-   pip install -e .[dev]
-   nosetests
+   $ bud test
 
 
 Documentation
@@ -93,23 +102,20 @@ Documentation
 Release
 =======
 
-First setup testpypi: https://packaging.python.org/guides/using-testpypi/
+Make sure you run the tests just before:
 
 .. code-block:: shell
 
-   $ rm -rf dist
+   $ bud test
 
-   $ python setup.py sdist bdist_wheel
-   ...
-
-   $ twine upload --repository testpypi dist/*
-   ...
-
-Go to https://test.pypi.org/project/pyramid-useragent/ to validate the result.
-
-Then upload to PyPI
+Create a new release:
 
 .. code-block:: shell
 
-   $ twine upload dist/*
-   ...
+   $ bud release 0.4.0
+
+Publish the release:
+
+.. code-block:: shell
+
+   $ bud publish

--- a/dev.yml
+++ b/dev.yml
@@ -1,5 +1,5 @@
 up:
-  - python: 2.7.13
+  - python: 3.6.6
   - pip:
     - requirements-dev.txt
   - python_develop
@@ -7,3 +7,8 @@ up:
 commands:
   test:
     run: nosetests
+
+  release:
+    run: pyreleaser create --only-on master --push
+  publish:
+    run: pyreleaser upload

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,3 @@
 ./[dev]
+
+pyreleaser==0.5.1


### PR DESCRIPTION
Setup PyReleaser to handle the release process.

Note: the version of Python used in local dev must be changed to 3.6+ first.  